### PR TITLE
Add restrictions to replace and create series

### DIFF
--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -154,6 +154,8 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrKeysPrivatePublicMismatch: "ErrKeysPrivatePublicMismatch",
 	ErrVotingPoolNotExists:       "ErrVotingPoolNotExists",
 	ErrScriptCreation:            "ErrScriptCreation",
+	ErrTooFewPublicKeys:          "ErrTooFewPublicKeys",
+	ErrTooManyReqSignatures:      "ErrTooManyReqSignatures",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/waddrmgr/pool.go
+++ b/waddrmgr/pool.go
@@ -158,6 +158,16 @@ func convertAndValidatePubKeys(rawPubKeys []string) ([]*hdkeychain.ExtendedKey, 
 }
 
 func (vp *VotingPool) putSeries(seriesID uint32, inRawPubKeys []string, reqSigs uint32) error {
+	if len(inRawPubKeys) < 3 {
+		str := fmt.Sprintf("Need at least three public keys to create a series")
+		return managerError(ErrTooFewPublicKeys, str, nil)
+	}
+
+	if reqSigs > uint32(len(inRawPubKeys)) {
+		str := fmt.Sprintf("The number of required signatures cannot be more than the number of keys")
+		return managerError(ErrTooManyReqSignatures, str, nil)
+	}
+
 	rawPubKeys := CanonicalKeyOrder(inRawPubKeys)
 
 	keys, err := convertAndValidatePubKeys(rawPubKeys)
@@ -180,8 +190,10 @@ func (vp *VotingPool) putSeries(seriesID uint32, inRawPubKeys []string, reqSigs 
 }
 
 // CreateSeries will create a new non-existing series
+//
+// rawPubKeys has to contain three or more public keys
+// reqSigs has to be less than the number of public keys in rawPubKeys
 func (vp *VotingPool) CreateSeries(seriesID uint32, rawPubKeys []string, reqSigs uint32) error {
-
 	if series := vp.GetSeries(seriesID); series != nil {
 		str := fmt.Sprintf("Series #%d already exists", seriesID)
 		return managerError(ErrSeriesAlreadyExists, str, nil)
@@ -190,7 +202,10 @@ func (vp *VotingPool) CreateSeries(seriesID uint32, rawPubKeys []string, reqSigs
 	return vp.putSeries(seriesID, rawPubKeys, reqSigs)
 }
 
-// ReplaceSeries will replace an already existing series
+// ReplaceSeries will replace an already existing series.
+//
+// rawPubKeys has to contain three or more public keys
+// reqSigs has to be less than the number of public keys in rawPubKeys
 func (vp *VotingPool) ReplaceSeries(seriesID uint32, rawPubKeys []string, reqSigs uint32) error {
 	series := vp.GetSeries(seriesID)
 	if series == nil {

--- a/waddrmgr/pool_error.go
+++ b/waddrmgr/pool_error.go
@@ -59,4 +59,12 @@ const (
 
 	// ErrScriptCreation indicates that the creation of a deposit script failed.
 	ErrScriptCreation
+
+	// ErrTooFewPublicKeys indicates that a required minimum of public
+	// keys was not met
+	ErrTooFewPublicKeys
+
+	// ErrTooManyReqSignatures indicates that too many required
+	// signatures are required
+	ErrTooManyReqSignatures
 )

--- a/waddrmgr/pool_test.go
+++ b/waddrmgr/pool_test.go
@@ -149,6 +149,57 @@ func TestCreateVotingPool(t *testing.T) {
 	}
 }
 
+func TestCreateSeriesTooFewKeys(t *testing.T) {
+	tearDown, _, pool := setUp(t)
+	defer tearDown()
+
+	if err := pool.CreateSeries(1, []string{pubKey0, pubKey1}, 1); err == nil {
+		t.Errorf("Created series with only two keys - minimum should is 3")
+	}
+}
+
+func TestCreateSeriesTooManyReqSigs(t *testing.T) {
+	tearDown, _, pool := setUp(t)
+	defer tearDown()
+
+	pubKeys := []string{pubKey0, pubKey1, pubKey3}
+	reqSigs := uint32(4)
+	if err := pool.CreateSeries(1, pubKeys, reqSigs); err == nil {
+		t.Errorf("Required signatures (%d) must not be more than the number of keys (%d)", reqSigs, len(pubKeys))
+	}
+}
+
+func TestReplaceSeriesTooFewKeys(t *testing.T) {
+	tearDown, _, pool := setUp(t)
+	defer tearDown()
+
+	if err := pool.CreateSeries(1, []string{pubKey0, pubKey1, pubKey3}, 1); err != nil {
+		t.Fatal("Created series with only two keys - minimum should is 3")
+	}
+
+	if err := pool.CreateSeries(1, []string{pubKey0, pubKey1, pubKey3}, 1); err == nil {
+		t.Errorf("Replaced series with only two keys - minimum should is 3")
+	}
+
+}
+
+func TestReplaceSeriesTooManyReqSigs(t *testing.T) {
+	tearDown, _, pool := setUp(t)
+	defer tearDown()
+
+	var reqSigs uint32 = 2
+	pubKeys := []string{pubKey0, pubKey1, pubKey3}
+	if err := pool.CreateSeries(1, pubKeys, reqSigs); err != nil {
+		t.Fatalf("Failed to create series", err)
+	}
+
+	reqSigs = 4
+	if err := pool.ReplaceSeries(1, pubKeys, reqSigs); err == nil {
+		t.Errorf("Required signatures (%d) <= number of keys (%d) requirement violated.", reqSigs, len(pubKeys))
+	}
+
+}
+
 func TestCreateSeries(t *testing.T) {
 	tearDown, _, pool := setUp(t)
 	defer tearDown()
@@ -523,7 +574,7 @@ func TestCannotReplaceEmpoweredSeries(t *testing.T) {
 
 	var seriesId uint32 = 1
 
-	if err := pool.CreateSeries(seriesId, []string{pubKey0, pubKey1}, 3); err != nil {
+	if err := pool.CreateSeries(seriesId, []string{pubKey0, pubKey1, pubKey2, pubKey3}, 3); err != nil {
 		t.Fatalf("Failed to create series", err)
 	}
 
@@ -531,7 +582,7 @@ func TestCannotReplaceEmpoweredSeries(t *testing.T) {
 		t.Fatalf("Failed to empower series", err)
 	}
 
-	if err := pool.ReplaceSeries(seriesId, []string{pubKey3}, 4); err == nil {
+	if err := pool.ReplaceSeries(seriesId, []string{pubKey0, pubKey2, pubKey3}, 2); err == nil {
 		t.Errorf("Replaced an empowered series. That should not be possible", err)
 	}
 
@@ -597,19 +648,6 @@ var replaceSeriesTestData = []replaceSeriesTestEntry{
 			reqSigs: 7,
 		},
 	},
-	{
-		testId: 3,
-		orig: seriesRaw{
-			id:      6,
-			pubKeys: []string{pubKey0},
-			reqSigs: 1,
-		},
-		replaceWith: seriesRaw{
-			id:      6,
-			pubKeys: waddrmgr.CanonicalKeyOrder([]string{pubKey0, pubKey1}),
-			reqSigs: 2,
-		},
-	},
 }
 
 func TestReplaceExistingSeries(t *testing.T) {
@@ -621,11 +659,11 @@ func TestReplaceExistingSeries(t *testing.T) {
 		testID := data.testId
 
 		if err := pool.CreateSeries(seriesID, data.orig.pubKeys, data.orig.reqSigs); err != nil {
-			t.Fatalf("Failed to create series in replace series setup", err)
+			t.Fatalf("Test #%d: Failed to create series in replace series setup", testID, err)
 		}
 
 		if err := pool.ReplaceSeries(seriesID, data.replaceWith.pubKeys, data.replaceWith.reqSigs); err != nil {
-			t.Errorf("ReplaceSeries failed: ", err)
+			t.Errorf("Test #%d: ReplaceSeries failed: ", testID, err)
 		}
 
 		validateReplaceSeries(t, pool, testID, data.replaceWith)


### PR DESCRIPTION
The minimum number of public keys is now three and the number of
required signatures must be less than the number of public keys
