### PR TITLE
Use explicit types for branch and index instead of uint32

### DIFF
--- a/votingpool/helpers_test.go
+++ b/votingpool/helpers_test.go
@@ -76,7 +76,7 @@ func createMsgTx(pkScript []byte, amts []int64) *btcwire.MsgTx {
 	return msgtx
 }
 
-func createVotingPoolPkScript(t *testing.T, mgr *waddrmgr.Manager, pool *votingpool.VotingPool, series, branch, index uint32) []byte {
+func createVotingPoolPkScript(t *testing.T, mgr *waddrmgr.Manager, pool *votingpool.VotingPool, series uint32, branch votingpool.Branch, index votingpool.Index) []byte {
 	script, err := pool.DepositScript(series, branch, index)
 	if err != nil {
 		t.Fatalf("Failed to create depositscript for series %d, branch %d, index %d: %v", series, branch, index, err)

--- a/votingpool/input_selection.go
+++ b/votingpool/input_selection.go
@@ -108,8 +108,8 @@ var _ sort.Interface = (*Credits)(nil)
 // AddressRange defines a range in the address space of the series.
 type AddressRange struct {
 	SeriesID                uint32
-	StartBranch, StopBranch uint32
-	StartIndex, StopIndex   uint32
+	StartBranch, StopBranch Branch
+	StartIndex, StopIndex   Index
 }
 
 // NumAddresses returns the number of addresses this range represents.

--- a/votingpool/input_selection_test.go
+++ b/votingpool/input_selection_test.go
@@ -27,10 +27,10 @@ type FakeTxShaCredit struct {
 	outputIndex uint32
 }
 
-func newFakeTxShaCredit(t *testing.T, vp *votingpool.VotingPool, series, index, branch int, txid []byte, outputIdx int) FakeTxShaCredit {
+func newFakeTxShaCredit(t *testing.T, vp *votingpool.VotingPool, series, index votingpool.Index, branch votingpool.Branch, txid []byte, outputIdx int) FakeTxShaCredit {
 	var hash btcwire.ShaHash
 	copy(hash[:], txid)
-	addr, err := vp.WithdrawalAddress(uint32(series), uint32(branch), uint32(index))
+	addr, err := vp.WithdrawalAddress(uint32(series), branch, index)
 	if err != nil {
 		t.Fatalf("WithdrawalAddress failed: %v", err)
 	}
@@ -109,8 +109,8 @@ func TestCreditInterfaceSort(t *testing.T) {
 func checkUniqueness(t *testing.T, credits votingpool.Credits) {
 	type uniq struct {
 		series      uint32
-		branch      uint32
-		index       uint32
+		branch      votingpool.Branch
+		index       votingpool.Index
 		hash        btcwire.ShaHash
 		outputIndex uint32
 	}
@@ -282,7 +282,9 @@ func TestEligibleInputsAreEligible(t *testing.T) {
 	store, storeTearDown := createTxStore(t)
 	defer teardown()
 	defer storeTearDown()
-	var seriesID, branch, index uint32 = 0, 0, 0
+	var seriesID uint32 = 0
+	var branch votingpool.Branch = 0
+	var index votingpool.Index = 0
 
 	// create the series
 	series := []seriesDef{
@@ -310,7 +312,9 @@ func TestNonEligibleInputsAreNotEligible(t *testing.T) {
 	defer teardown()
 	defer storeTearDown1()
 	defer storeTearDown2()
-	var seriesID, branch, index uint32 = 0, 0, 0
+	var seriesID uint32 = 0
+	var branch votingpool.Branch = 0
+	var index votingpool.Index = 0
 
 	// create the series
 	series := []seriesDef{

--- a/votingpool/pool_test.go
+++ b/votingpool/pool_test.go
@@ -263,7 +263,7 @@ func TestDepositScriptAddress(t *testing.T) {
 			t.Fatalf("Cannot creates series %v", test.series)
 		}
 		for branch, expectedAddress := range test.addresses {
-			addr, err := pool.DepositScriptAddress(test.series, branch, 0)
+			addr, err := pool.DepositScriptAddress(test.series, votingpool.Branch(branch), votingpool.Index(0))
 			if err != nil {
 				t.Fatalf("Failed to get DepositScriptAddress #%d: %v", i, err)
 			}
@@ -299,7 +299,7 @@ func TestDepositScriptAddressForHardenedPubKey(t *testing.T) {
 
 	// Ask for a DepositScriptAddress using an index for a hardened child, which should
 	// fail as we use the extended public keys to derive childs.
-	_, err := pool.DepositScriptAddress(0, 0, uint32(hdkeychain.HardenedKeyStart+1))
+	_, err := pool.DepositScriptAddress(0, 0, votingpool.Index(hdkeychain.HardenedKeyStart+1))
 
 	if err == nil {
 		t.Fatalf("Expected an error, got none")
@@ -1039,7 +1039,7 @@ func TestBranchOrderNonZero(t *testing.T) {
 
 			inKeys := append(append(first, pivot...), last...)
 			wantKeys := append(append(pivot, first...), last...)
-			resKeys, err := votingpool.TstBranchOrder(inKeys, uint32(branch))
+			resKeys, err := votingpool.TstBranchOrder(inKeys, votingpool.Branch(branch))
 			if err != nil {
 				t.Fatalf("Error ordering keys: %v", err)
 			}

--- a/votingpool/withdrawal.go
+++ b/votingpool/withdrawal.go
@@ -64,10 +64,10 @@ func init() {
 	log, _ = btclog.NewLoggerFromWriter(os.Stdout, btclog.DebugLvl)
 }
 
-func (vp *VotingPool) ChangeAddress(seriesID, index uint32) (*ChangeAddress, error) {
+func (vp *VotingPool) ChangeAddress(seriesID uint32, index Index) (*ChangeAddress, error) {
 	// TODO: Ensure the given series is active.
 	// Branch is always 0 for change addresses.
-	branch := uint32(0)
+	branch := Branch(0)
 	addr, err := vp.DepositScriptAddress(seriesID, branch, index)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (vp *VotingPool) ChangeAddress(seriesID, index uint32) (*ChangeAddress, err
 	return &ChangeAddress{vp: vp, votingPoolAddress: vpAddr}, nil
 }
 
-func (vp *VotingPool) WithdrawalAddress(seriesID, branch, index uint32) (*WithdrawalAddress, error) {
+func (vp *VotingPool) WithdrawalAddress(seriesID uint32, branch Branch, index Index) (*WithdrawalAddress, error) {
 	// TODO: Ensure the given series is hot.
 	addr, err := vp.DepositScriptAddress(seriesID, branch, index)
 	if err != nil {
@@ -89,8 +89,8 @@ func (vp *VotingPool) WithdrawalAddress(seriesID, branch, index uint32) (*Withdr
 type votingPoolAddress struct {
 	addr     btcutil.Address
 	seriesID uint32
-	branch   uint32
-	index    uint32
+	branch   Branch
+	index    Index
 }
 
 func (a *votingPoolAddress) Addr() btcutil.Address {
@@ -101,11 +101,11 @@ func (a votingPoolAddress) SeriesID() uint32 {
 	return a.seriesID
 }
 
-func (a votingPoolAddress) Branch() uint32 {
+func (a votingPoolAddress) Branch() Branch {
 	return a.branch
 }
 
-func (a votingPoolAddress) Index() uint32 {
+func (a votingPoolAddress) Index() Index {
 	return a.index
 }
 

--- a/votingpool/withdrawal_test.go
+++ b/votingpool/withdrawal_test.go
@@ -159,7 +159,7 @@ func createCredits(
 
 	// Finally create the Credit instances, locked to the voting pool's deposit
 	// address with branch==0, index==0.
-	branch := uint32(0)
-	pkScript := createVotingPoolPkScript(t, mgr, pool, seriesID, branch, idx)
+	branch := votingpool.Branch(0)
+	pkScript := createVotingPoolPkScript(t, mgr, pool, seriesID, branch, votingpool.Index(idx))
 	return createInputs(t, store, pkScript, amounts)
 }


### PR DESCRIPTION
It is easy to mix up the index and branch if they are both uint32. Introducing explicity types for these makes it impossible to confuse them by mistake.
