### PR TITLE
Refactor a bunch of our test helpers to make them more flexible

### DIFF
--- a/txstore/tx.go
+++ b/txstore/tx.go
@@ -1096,9 +1096,9 @@ func (s *Store) UnspentOutputs() ([]Credit, error) {
 	return s.unspentOutputs()
 }
 
-// XXX: Maybe return the PkScript directly as that's the only thing we need from the returned TxOut
-// UnconfirmedSpent returns the output with the given outpoint, spent by an unconfirmed
-// transaction.
+// UnconfirmedSpent returns the TxOut for the given OutPoint, spent by an
+// unconfirmed transaction.
+// TODO: Test this!
 func (s *Store) UnconfirmedSpent(outpoint btcwire.OutPoint) (*btcwire.TxOut, error) {
 	for op, key := range s.unconfirmed.spentBlockOutPointKeys {
 		if reflect.DeepEqual(outpoint, op) {
@@ -1109,7 +1109,8 @@ func (s *Store) UnconfirmedSpent(outpoint btcwire.OutPoint) (*btcwire.TxOut, err
 			return r.Tx().MsgTx().TxOut[outpoint.Index], nil
 		}
 	}
-	return nil, errors.New(fmt.Sprintf("Outpoint not found: %v", outpoint))
+	return nil, errors.New(
+		fmt.Sprintf("outpoint not found in unconfirmed transactions: %v", outpoint))
 }
 
 func (s *Store) unspentOutputs() ([]Credit, error) {

--- a/votingpool/input_selection_test.go
+++ b/votingpool/input_selection_test.go
@@ -29,8 +29,8 @@ func TestCreditInterfaceSort(t *testing.T) {
 	// Create the series 0 and 1 as they are needed for creaing the
 	// fake credits.
 	series := []vp.TstSeriesDef{
-		{2, []string{pubKey1, pubKey2, pubKey3}, 0},
-		{2, []string{pubKey3, pubKey4, pubKey5}, 1},
+		{ReqSigs: 2, PubKeys: []string{pubKey1, pubKey2, pubKey3}, SeriesID: 0},
+		{ReqSigs: 2, PubKeys: []string{pubKey3, pubKey4, pubKey5}, SeriesID: 1},
 	}
 	vp.TstCreateSeries(t, pool, series)
 
@@ -135,8 +135,8 @@ func TestGetEligibleInputs(t *testing.T) {
 	}
 	// define two series.
 	series := []vp.TstSeriesDef{
-		{2, []string{pubKey1, pubKey2, pubKey3}, aRanges[0].SeriesID},
-		{2, []string{pubKey3, pubKey4, pubKey5}, aRanges[1].SeriesID},
+		{ReqSigs: 2, PubKeys: []string{pubKey1, pubKey2, pubKey3}, SeriesID: aRanges[0].SeriesID},
+		{ReqSigs: 2, PubKeys: []string{pubKey3, pubKey4, pubKey5}, SeriesID: aRanges[1].SeriesID},
 	}
 	oldChainHeight := 11112
 	chainHeight := oldChainHeight + minConf + 10
@@ -198,7 +198,7 @@ func TestGetEligibleInputsFromSeries(t *testing.T) {
 
 	// define a series.
 	series := []vp.TstSeriesDef{
-		{2, []string{pubKey1, pubKey2, pubKey3}, aRange.SeriesID},
+		{ReqSigs: 2, PubKeys: []string{pubKey1, pubKey2, pubKey3}, SeriesID: aRange.SeriesID},
 	}
 	vp.TstCreateSeries(t, pool, series)
 
@@ -246,8 +246,8 @@ func TestEligibleInputsAreEligible(t *testing.T) {
 
 	// create the series
 	series := []vp.TstSeriesDef{
-		{3, []string{pubKey1, pubKey2, pubKey3, pubKey4, pubKey5}, seriesID},
-	}
+		{ReqSigs: 3, PubKeys: []string{pubKey1, pubKey2, pubKey3, pubKey4, pubKey5},
+			SeriesID: seriesID}}
 	vp.TstCreateSeries(t, pool, series)
 
 	// Create the input.
@@ -274,8 +274,8 @@ func TestNonEligibleInputsAreNotEligible(t *testing.T) {
 
 	// create the series
 	series := []vp.TstSeriesDef{
-		{3, []string{pubKey1, pubKey2, pubKey3, pubKey4, pubKey5}, seriesID},
-	}
+		{ReqSigs: 3, PubKeys: []string{pubKey1, pubKey2, pubKey3, pubKey4, pubKey5},
+			SeriesID: seriesID}}
 	vp.TstCreateSeries(t, pool, series)
 
 	pkScript := vp.TstCreatePkScript(t, pool, seriesID, branch, index)

--- a/votingpool/withdrawal_wb_test.go
+++ b/votingpool/withdrawal_wb_test.go
@@ -187,12 +187,12 @@ func TestWithdrawalTxOutputs(t *testing.T) {
 	defer tearDown()
 
 	// Create eligible inputs and the list of outputs we need to fulfil.
-	eligible := TstCreateCredits(t, pool, []int64{2e6, 4e6}, store)
+	seriesID, eligible := TstCreateCredits(t, pool, []int64{2e6, 4e6}, store)
 	outputs := []*OutputRequest{
 		NewOutputRequest("foo", 1, "34eVkREKgvvGASZW7hkgE2uNc1yycntMK6", btcutil.Amount(3e6)),
 		NewOutputRequest("foo", 2, "3PbExiaztsSYgh6zeMswC49hLUwhTQ86XG", btcutil.Amount(2e6)),
 	}
-	changeStart, err := pool.ChangeAddress(0, 0)
+	changeStart, err := pool.ChangeAddress(seriesID, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,10 +222,10 @@ func TestFulfilOutputsNoSatisfiableOutputs(t *testing.T) {
 	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
-	eligible := TstCreateCredits(t, pool, []int64{1e6}, store)
+	seriesID, eligible := TstCreateCredits(t, pool, []int64{1e6}, store)
 	outputs := []*OutputRequest{
 		NewOutputRequest("foo", 1, "3Qt1EaKRD9g9FeL2DGkLLswhK1AKmmXFSe", btcutil.Amount(3e6))}
-	changeStart, err := pool.ChangeAddress(0, 0)
+	changeStart, err := pool.ChangeAddress(seriesID, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,12 +257,12 @@ func TestFulfilOutputsNotEnoughCreditsForAllRequests(t *testing.T) {
 	defer tearDown()
 
 	// Create eligible inputs and the list of outputs we need to fulfil.
-	eligible := TstCreateCredits(t, pool, []int64{2e6, 4e6}, store)
+	seriesID, eligible := TstCreateCredits(t, pool, []int64{2e6, 4e6}, store)
 	out1 := NewOutputRequest("foo", 1, "34eVkREKgvvGASZW7hkgE2uNc1yycntMK6", btcutil.Amount(3e6))
 	out2 := NewOutputRequest("foo", 2, "3PbExiaztsSYgh6zeMswC49hLUwhTQ86XG", btcutil.Amount(2e6))
 	out3 := NewOutputRequest("foo", 3, "3Qt1EaKRD9g9FeL2DGkLLswhK1AKmmXFSe", btcutil.Amount(5e6))
 	outputs := []*OutputRequest{out1, out2, out3}
-	changeStart, err := pool.ChangeAddress(0, 0)
+	changeStart, err := pool.ChangeAddress(seriesID, 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This also changes most of them use unique IDs for the DB entries they create,
meaning they can now be called multiple times in a single test.

My next branch will get rid of some duplication by reusing those more
flexible functions. This is just the first step
