### PR TITLE
New tests for signMultiSigUTXO (previously SignMultiSigUTXO)

### DIFF
--- a/votingpool/error.go
+++ b/votingpool/error.go
@@ -125,6 +125,9 @@ const (
 	// preconditon has not been met.
 	ErrPreconditionNotMet
 
+	// ErrTxSigning indicates an error when signing a transaction.
+	ErrTxSigning
+
 	// lastErr is used for testing, making it possible to iterate over
 	// the error codes in order to check that they all have proper
 	// translations in errorCodeStrings.
@@ -161,6 +164,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrCrypto:                  "ErrCrypto",
 	ErrRawSigning:              "ErrRawSigning",
 	ErrPreconditionNotMet:      "ErrPreconditionNotMet",
+	ErrTxSigning:               "ErrTxSigning",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/votingpool/error_wb_test.go
+++ b/votingpool/error_wb_test.go
@@ -55,6 +55,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrCrypto, "ErrCrypto"},
 		{ErrRawSigning, "ErrRawSigning"},
 		{ErrPreconditionNotMet, "ErrPreconditionNotMet"},
+		{ErrTxSigning, "ErrTxSigning"},
 	}
 
 	if int(lastErr) != len(tests) {

--- a/votingpool/factory_test.go
+++ b/votingpool/factory_test.go
@@ -66,18 +66,6 @@ func createDecoratedTx(t *testing.T, pool *Pool, store *txstore.Store, inputAmou
 	return tx
 }
 
-// createTxWithInputAmounts returns a new decoratedTx containing just inputs
-// with the given amounts.
-func createTxWithInputAmounts(
-	t *testing.T, pool *Pool, amounts []int64, store *txstore.Store) *decoratedTx {
-	tx := newDecoratedTx()
-	_, credits := TstCreateCredits(t, pool, amounts, store)
-	for _, c := range credits {
-		tx.addTxIn(c)
-	}
-	return tx
-}
-
 func createMsgTx(pkScript []byte, amts []int64) *btcwire.MsgTx {
 	msgtx := &btcwire.MsgTx{
 		Version: 1,


### PR DESCRIPTION
signMultiSigUTXO now also calls validateSigScript() to ensure the sigscript
it generates will execute later on.

New SignTx() function which signs all inputs of a given tx.

Plus removal of createTxWithInputAmounts, which is no longer needed as we
have the more flexible createDecoratedTx.

And last but not least, some fixes for issues pointed out by go vet.
